### PR TITLE
feat(core): turn read models into profunctors

### DIFF
--- a/eventsourcing/CHANGELOG.md
+++ b/eventsourcing/CHANGELOG.md
@@ -7,7 +7,7 @@
 * `TopUpReadModel`: A read model which fetches a projected state from an
   underlying read model, looks for new events since the projection last ran and
   applies an aggregator.
-* Add `ReadModelF` to turn any read model into a functor.
+* Add `ReadModelP` to turn any read model into a profunctor.
 
 ## 0.9.0 -- 2020-08-16
 

--- a/eventsourcing/eventsourcing.cabal
+++ b/eventsourcing/eventsourcing.cabal
@@ -48,6 +48,7 @@ library
     hashable,
     mtl,
     pipes >=4.3,
+    profunctors,
     psqueues >=0.2,
     stm >=2.5,
     time,

--- a/eventsourcing/src/Database/CQRS.hs
+++ b/eventsourcing/src/Database/CQRS.hs
@@ -34,8 +34,11 @@ module Database.CQRS
 
     -- * Read models
   , ReadModel(..)
-  , ReadModelF
-  , toReadModelF
+  , AllF
+  , ReadModelP
+  , toReadModelP
+  , toReadModelP'
+  , bindReadModelP
 
     -- * Transformers
   , Transformer

--- a/eventsourcing/src/Database/CQRS/Projection.hs
+++ b/eventsourcing/src/Database/CQRS/Projection.hs
@@ -1,11 +1,12 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveFunctor          #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase             #-}
+{-# LANGUAGE RecordWildCards        #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TupleSections          #-}
+{-# LANGUAGE TypeApplications       #-}
 
 module Database.CQRS.Projection
   ( Aggregator
@@ -20,15 +21,15 @@ module Database.CQRS.Projection
   ) where
 
 import Control.Monad
-import Control.Monad.Trans (MonadIO(..), lift)
-import Data.Hashable (Hashable)
-import Data.Tuple (swap)
-import Pipes ((>->))
+import Control.Monad.Trans (MonadIO (..), lift)
+import Data.Hashable       (Hashable)
+import Data.Tuple          (swap)
+import Pipes               ((>->))
 
-import qualified Data.HashMap.Strict        as HM
 import qualified Control.Concurrent.STM     as STM
 import qualified Control.Monad.Except       as Exc
 import qualified Control.Monad.State.Strict as St
+import qualified Data.HashMap.Strict        as HM
 import qualified Pipes
 
 import Database.CQRS.Error
@@ -212,7 +213,7 @@ runProjection streamFamily initState projection trackingTable
         -- should retry.
         FailureAt mSuccess eventId _ -> do
           let check = \case
-                Left (eventId', _) -> eventId' <= eventId
+                Left (eventId', _)         -> eventId' <= eventId
                 Right EventWithContext{..} -> identifier <= eventId
           when (any check eEvents) $
             case mSuccess of
@@ -315,7 +316,7 @@ stopOnLeft = go id
   where
     go :: ([b] -> [b]) -> [Either a b] -> ([b], Maybe a)
     go f = \case
-      [] -> (f [], Nothing)
+      []           -> (f [], Nothing)
       Left err : _ -> (f [], Just err)
       Right x : xs -> go (f . (x:)) xs
 
@@ -324,7 +325,7 @@ data TrackedState identifier st
   | SuccessAt identifier st
   | FailureAt (Maybe (identifier, st)) identifier String
     -- ^ Last succeeded at, failed at.
-  deriving (Eq, Show)
+  deriving (Eq, Show, Functor)
 
 class
     TrackingTable m table streamId eventId st
@@ -356,7 +357,7 @@ instance
     liftIO . STM.atomically . STM.modifyTVar tvar $
       HM.alter
         (\case
-          Nothing -> Just (Nothing, Just (eventId, err))
+          Nothing            -> Just (Nothing, Just (eventId, err))
           Just (mSuccess, _) -> Just (mSuccess, Just (eventId, err)))
         streamId
 

--- a/eventsourcing/src/Database/CQRS/ReadModel.hs
+++ b/eventsourcing/src/Database/CQRS/ReadModel.hs
@@ -1,13 +1,28 @@
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ConstraintKinds           #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
+{-# LANGUAGE PolyKinds                 #-}
+{-# LANGUAGE QuantifiedConstraints     #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
 
 module Database.CQRS.ReadModel
   ( ReadModel(..)
-  , ReadModelF(..)
-  , toReadModelF
+  , AllF
+  , ReadModelP(..)
+  , toReadModelP
+  , toReadModelP'
+  , bindReadModelP
   ) where
+
+import Control.Monad   ((>=>))
+import Data.Kind       (Constraint, Type)
+import Data.Profunctor
 
 class ReadModel f model where
   type ReadModelQuery    model :: *
@@ -15,24 +30,63 @@ class ReadModel f model where
 
   query :: model -> ReadModelQuery model -> f (ReadModelResponse model)
 
--- | Turn a read model into a functor.
-data ReadModelF model a = ReadModelF
-  { readModel :: model
-  , transform :: ReadModelResponse model -> a
-  }
+type family AllF
+    (cs :: [(Type -> Type) -> Constraint])
+    (f :: Type -> Type) :: Constraint where
+  AllF '[] f = ()
+  AllF (c ': cs) f = (c f, AllF cs f)
 
-instance Functor (ReadModelF model) where
-  fmap f ReadModelF{..} = ReadModelF { transform = f . transform, .. }
+-- | Turn a read model into a profunctor.
+data ReadModelP cs a b =
+  forall model. (forall f. AllF cs f => ReadModel f model) => ReadModelP
+    { readModel         :: model
+    , transformQuery    :: a -> ReadModelQuery model
+    , transformResponse
+        :: forall f. (Monad f, AllF cs f)
+        => (ReadModelQuery model, ReadModelResponse model) -> f b
+    }
 
-instance (Functor f, ReadModel f model) => ReadModel f (ReadModelF model a) where
-  type ReadModelQuery (ReadModelF model a) = ReadModelQuery model
-  type ReadModelResponse (ReadModelF model a) = a
+instance Functor (ReadModelP cs a) where
+  fmap f ReadModelP{..} =
+    ReadModelP { transformResponse = fmap f . transformResponse, .. }
+
+instance Profunctor (ReadModelP cs) where
+  lmap f ReadModelP{..} = ReadModelP { transformQuery = transformQuery . f, .. }
+  rmap = fmap
+
+instance (Monad f, AllF cs f) => ReadModel f (ReadModelP cs a b) where
+  type ReadModelQuery (ReadModelP cs a b) = a
+  type ReadModelResponse (ReadModelP cs a b) = b
   query = readModelFQuery
 
-readModelFQuery
-  :: (Functor f, ReadModel f model)
-  => ReadModelF model a -> ReadModelQuery model -> f a
-readModelFQuery ReadModelF{..} = fmap transform . query readModel
+readModelFQuery :: (Monad f, AllF cs f) => ReadModelP cs a b -> a -> f b
+readModelFQuery ReadModelP{..} q = do
+  let q' = transformQuery q
+  r <- query readModel q'
+  transformResponse (q', r)
 
-toReadModelF :: model -> ReadModelF model (ReadModelResponse model)
-toReadModelF readModel = ReadModelF { transform = id, .. }
+bindReadModelP
+  :: (forall m. (Monad m, AllF cs m) => b -> m c)
+  -> ReadModelP cs a b
+  -> ReadModelP cs a c
+bindReadModelP f ReadModelP{..} =
+  ReadModelP { transformResponse = transformResponse >=> f, .. }
+
+toReadModelP'
+  :: (forall f. AllF cs f => ReadModel f model)
+  => model
+  -> ReadModelP cs
+      (ReadModelQuery model)
+      (ReadModelQuery model, ReadModelResponse model)
+toReadModelP' readModel =
+  ReadModelP
+    { transformQuery = id
+    , transformResponse = pure
+    , ..
+    }
+
+toReadModelP
+  :: (forall f. AllF cs f => ReadModel f model)
+  => model
+  -> ReadModelP cs (ReadModelQuery model) (ReadModelResponse model)
+toReadModelP = fmap snd . toReadModelP'


### PR DESCRIPTION
Generalise 'toReadModelF' to create a profunctor instead.