### PR TITLE
feat(postgres): helpers for migrations

### DIFF
--- a/eventsourcing-postgresql/CHANGELOG.md
+++ b/eventsourcing-postgresql/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed Pipes.Consumer from helper functions.
 * Add `TrackedSQLQuery` to run a SQL query while fetching the state from a
   tracking table at the same time. This can be useful with `TopUpReadModel`.
+* Add helpers for migrations: `lockTable` and `swapTables`.
 
 ## 0.9.0 -- 2020-08-16
 

--- a/eventsourcing-postgresql/LICENSE
+++ b/eventsourcing-postgresql/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019-2020 Tom Feron <tho.feron@gmail.com>
+Copyright 2019-2021 Tom Feron <tho.feron@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 

--- a/eventsourcing/LICENSE
+++ b/eventsourcing/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019-2020 Tom Feron <tho.feron@gmail.com>
+Copyright 2019-2021 Tom Feron <tho.feron@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
It adds two helper functions: `lockTable` and `swapTables`.